### PR TITLE
bugfix: 更新flask版本指定为1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'aliyun-python-sdk-core-v3==2.13.3',
         'pyyaml',
         'ratelimiter',
-        'flask',
+        'flask==1.1.0',
         'cachetools',
         'werkzeug==0.16.0',
         'aliyun-python-sdk-ecs==4.16.5',


### PR DESCRIPTION
新版flask使用的werkzeug组件为2.0版，和0.16.0版本不兼容.